### PR TITLE
fix: delete connection close

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -70,7 +70,6 @@ func (c *Client) PostWithURLJSONParams(url string, params any, headers http.Head
 	}
 
 	headers.Set("Content-Type", "application/json")
-	headers.Set("Connection", "close")
 
 	req.Header = headers
 

--- a/client/client.go
+++ b/client/client.go
@@ -90,7 +90,6 @@ func (c *Client) PostWithURLEncodedParams(url string, params url.Values, headers
 	}
 
 	headers.Set("Content-Type", "application/x-www-form-urlencoded")
-	headers.Set("Connection", "close")
 
 	req.Header = headers
 
@@ -110,7 +109,6 @@ func (c *Client) PutWithURLJSONParams(url string, params any, headers http.Heade
 	}
 
 	headers.Set("Content-Type", "application/json")
-	headers.Set("Connection", "close")
 
 	req.Header = headers
 


### PR DESCRIPTION
Delete header shouldn't be mandatory